### PR TITLE
Add brew formula for Maven

### DIFF
--- a/docs/contributing/development/building-status.md
+++ b/docs/contributing/development/building-status.md
@@ -16,7 +16,7 @@ This guide is written with OS X in mind.
 - [Genymotion](https://www.genymotion.com) (optional, you may use an Android Virtual Device or real device)
 - [Setup Android Development Environment / Simulator](https://facebook.github.io/react-native/docs/android-setup.html)
 - GIT over SSH, please add public key to Github
-- [Maven](https://maven.apache.org/install.html)
+- [Maven](https://maven.apache.org/install.html) `brew install maven`
 - [Cocoapods](https://cocoapods.org) `sudo gem install cocoapods`
 
 ### Dependencies & Setup


### PR DESCRIPTION
There's a Homebrew formula for installing Maven, so lets add it along the rest of them in the suilding status section for the OS X users.