### PR TITLE
Update building-status.md

### DIFF
--- a/docs/contributing/development/building-status.md
+++ b/docs/contributing/development/building-status.md
@@ -40,7 +40,7 @@ require('./node_modules/re-natal/index.js');
 ### Dependencies & Setup
     $ git clone git@github.com:status-im/status-react.git -b master && cd status-react
     # or
-    $ git clone git@github.com:status-im/status-react.git -b develop && cd status-react
+    $ git clone git@github.com:status-im/status-react.git -b master && cd status-react && git checkout -b develop
 
     $ lein deps && npm install && ./re-natal deps && lein generate-externs && ./re-natal use-figwheel && lein re-frisk use-re-natal && ./re-natal enable-source-maps
     $ mvn -f modules/react-native-status/ios/RCTStatus dependency:unpack


### PR DESCRIPTION
Building `develop` branch requires `master` branch to be present for iOS Plist version information.