### PR TITLE
Update building-status.md

### DIFF
--- a/docs/contributing/development/building-status.md
+++ b/docs/contributing/development/building-status.md
@@ -19,7 +19,7 @@ This guide is written with OS X in mind.
 - GIT over SSH, please add public key to Github
 - [Maven](https://maven.apache.org/install.html) `brew install maven`
 - For Windows, [Ruby](https://www.ruby-lang.org/en/) `choco install ruby`
-- [Cocoapods](https://cocoapods.org) `sudo gem install cocoapods`.
+- [Cocoapods](https://cocoapods.org) `sudo gem install cocoapods` or `brew install cocoapods`
 
 #### Windows-specific Setup Notes
 Setting up a development instance in Windows requires some tweaks. Consider the following before attempting the following sections:


### PR DESCRIPTION
add alternative `cocoapods` installation option for macos